### PR TITLE
Fixed bug triggered by leading empty columns in sparse Hessians.

### DIFF
--- a/src/matlab/mcutest.c
+++ b/src/matlab/mcutest.c
@@ -2078,7 +2078,7 @@ mexErrMsgTxt("stop\n");
       }
 
     /* Restore jptr */
-    for (j = ncol-1; j >= 1; j--) jptr[j] = jptr[j-1];
+    for (j = ncol; j >= 1; j--) jptr[j] = jptr[j-1];
     jptr[0] = (mwIndex)0;
 
     /* Sort each segment of ir in ascending order (a silly Matlab thing).
@@ -2087,7 +2087,7 @@ mexErrMsgTxt("stop\n");
 
     for (j = 0; j < ncol; j++)
       /* sort row indices in column j if it is nonempty */
-      if ( jptr[j] < jptr[j+1]-1)
+      if ( jptr[j]+1 < jptr[j+1])
         quicksort_cutest(ir, (double*)pr, jptr[j], jptr[j+1]-1);
 
     return matrix;


### PR DESCRIPTION
Matlab crashed when computing a sparse Hessian of FREURONE. Its sparsity pattern is
```
[0 0]
[0 *]
```
Without the patch, ``jptr`` ends up being ``{0, 0, 0}`` (``{0, 0, 1}`` is correct). The unsigned integer difference ``0-1 = 18446744073709551615`` invalidates the comparison in line 2090 and triggers a memory access violation in the sorting step.