### PR TITLE
fix time types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,7 @@ script:
   - ./bin/runcutest -p genc
   - ./bin/runcutest -p gen90
   - ./bin/runcutest -p stats
+  - ./bin/runcutest --single -p gen77
+  - ./bin/runcutest --single -p genc
+  - ./bin/runcutest --single -p gen90
+  - ./bin/runcutest --single -p stats

--- a/src/tools/ccfg.f90
+++ b/src/tools/ccfg.f90
@@ -205,7 +205,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, icon, nin, nvarel, nelow
       INTEGER :: icnt, ifstat, igstat, nelup, istrgv, iendgv
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/ccfsg.f90
+++ b/src/tools/ccfsg.f90
@@ -200,7 +200,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, icon, icnt
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cchprods.f90
+++ b/src/tools/cchprods.f90
@@ -187,7 +187,7 @@
       INTEGER :: i, ic, iel, iell, ielhst, ifstat, igstat, ig, ii, irow
       INTEGER :: ijhess, j, jcol, k, l, ll, ls, lthvar, nvarel, nin
       REAL ( KIND = wp ) :: ftt, gdash, g2dash, gi, pi, prod, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nullwk
       EXTERNAL :: RANGE
 

--- a/src/tools/cchprodsp.f90
+++ b/src/tools/cchprodsp.f90
@@ -69,7 +69,7 @@
 !  local variables
 
       INTEGER :: i, ic, ig, ls
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/ccifg.f90
+++ b/src/tools/ccifg.f90
@@ -171,7 +171,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, neling
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nontrv
       INTEGER, DIMENSION( 1 ) :: ICALCG
       EXTERNAL :: RANGE

--- a/src/tools/ccifsg.f90
+++ b/src/tools/ccifsg.f90
@@ -189,7 +189,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, neling
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       INTEGER, DIMENSION( 1 ) :: ICALCG
       EXTERNAL :: RANGE
 

--- a/src/tools/cconst.f90
+++ b/src/tools/cconst.f90
@@ -103,7 +103,7 @@
 !  local variables
 
       INTEGER :: ig
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/cdh.f90
+++ b/src/tools/cdh.f90
@@ -128,7 +128,7 @@
       INTEGER :: i, ig, j, k, nnzh, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cdhc.f90
+++ b/src/tools/cdhc.f90
@@ -126,7 +126,7 @@
 
       INTEGER :: i, ig, j, k, nnzh, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ceh.f90
+++ b/src/tools/ceh.f90
@@ -283,7 +283,7 @@
       INTEGER :: i, ig, j, ifstat, igstat, alloc_status
       INTEGER :: lhe_row_int, lhe_val_int
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/cfn.f90
+++ b/src/tools/cfn.f90
@@ -111,7 +111,7 @@
 
       INTEGER :: i, j, ig, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/cgr.f90
+++ b/src/tools/cgr.f90
@@ -222,7 +222,7 @@
       INTEGER :: nelow, nelup, istrgv, iendgv, ifstat, igstat
       LOGICAL :: nontrv
       REAL ( KIND = wp ) :: ftt, gi, scalee, gii
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cgrdh.f90
+++ b/src/tools/cgrdh.f90
@@ -254,7 +254,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, jj, ll, nnzh, iendgv, icon
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt, gi, gii, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nontrv
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE

--- a/src/tools/chcprod.f90
+++ b/src/tools/chcprod.f90
@@ -170,7 +170,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/chprod.f90
+++ b/src/tools/chprod.f90
@@ -170,7 +170,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cidh.f90
+++ b/src/tools/cidh.f90
@@ -131,7 +131,7 @@
       INTEGER :: i, ig, j, ncalcf, ncalcg, ifstat, igstat, k, nnzh, alloc_status
       REAL ( KIND = wp ) :: ftt
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cifn.f90
+++ b/src/tools/cifn.f90
@@ -111,7 +111,7 @@
 
       INTEGER :: i, j, iel, ig, ii, ncalcg, neling, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       INTEGER, DIMENSION( 1 ) :: ICALCG
       EXTERNAL :: RANGE
 

--- a/src/tools/cigr.f90
+++ b/src/tools/cigr.f90
@@ -123,7 +123,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, ncalcg, neling
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nontrv
       INTEGER, DIMENSION( 1 ) :: ICALCG
       EXTERNAL :: RANGE

--- a/src/tools/cisgr.f90
+++ b/src/tools/cisgr.f90
@@ -135,7 +135,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, ncalcg, neling
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nontrv
       INTEGER, DIMENSION( 1 ) :: ICALCG
       EXTERNAL :: RANGE

--- a/src/tools/cish.f90
+++ b/src/tools/cish.f90
@@ -135,7 +135,7 @@
       INTEGER :: i, ig, j, ncalcf, ncalcg, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cjprod.f90
+++ b/src/tools/cjprod.f90
@@ -184,7 +184,7 @@
       INTEGER :: l, iel, nvarel, nin
       INTEGER :: ifstat, igstat
       REAL ( KIND = wp ) :: ftt, prod, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/clfg.f90
+++ b/src/tools/clfg.f90
@@ -182,7 +182,7 @@
       INTEGER :: nelow, nelup, istrgv, iendgv, ifstat, igstat
       LOGICAL :: nontrv
       REAL ( KIND = wp ) :: ftt, gi, scalee, gii
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cofg.f90
+++ b/src/tools/cofg.f90
@@ -169,7 +169,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, icon, icnt, ifstat, igstat
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cofsg.f90
+++ b/src/tools/cofsg.f90
@@ -178,7 +178,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, ll, icon, icnt, ifstat, igstat
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv
       REAL ( KIND = wp ) :: ftt, gi, scalee
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/creport.f90
+++ b/src/tools/creport.f90
@@ -155,7 +155,7 @@
 
 !  local variable
 
-      REAL ( KIND = wp ) :: time_now
+      REAL :: time_now
 
       CALL CPU_TIME( time_now )
 

--- a/src/tools/csgr.f90
+++ b/src/tools/csgr.f90
@@ -208,7 +208,7 @@
       INTEGER :: i, j, iel, k, ig, ii, ig1, l, jj, ll, icon, ifstat, igstat
       INTEGER :: nin, nvarel, nelow, nelup, istrgv, iendgv
       REAL ( KIND = wp ) :: ftt, gi, scalee, gii
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       LOGICAL :: nontrv
       EXTERNAL :: RANGE
 

--- a/src/tools/csgreh.f90
+++ b/src/tools/csgreh.f90
@@ -308,7 +308,7 @@
       LOGICAL :: nontrv
       REAL ( KIND = wp ) :: ftt, gi, scalee, gii
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/csgrp.f90
+++ b/src/tools/csgrp.f90
@@ -76,7 +76,7 @@
       INTEGER :: i, j, ig, ig1, icon, alloc_status
       INTEGER :: nin, nvarel, istrgv
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/csgrsh.f90
+++ b/src/tools/csgrsh.f90
@@ -259,7 +259,7 @@
       REAL ( KIND = wp ) :: ftt, gi, scalee, gii
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       LOGICAL :: nontrv
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/csgrshp.f90
+++ b/src/tools/csgrshp.f90
@@ -86,7 +86,7 @@
       INTEGER :: i, j, ig, ig1, icon, alloc_status
       INTEGER :: nin, nvarel, istrgv
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/csh.f90
+++ b/src/tools/csh.f90
@@ -132,7 +132,7 @@
       INTEGER :: i, ig, j, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cshc.f90
+++ b/src/tools/cshc.f90
@@ -138,7 +138,7 @@
       INTEGER :: i, ig, j, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cshcprod.f90
+++ b/src/tools/cshcprod.f90
@@ -208,7 +208,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cshp.f90
+++ b/src/tools/cshp.f90
@@ -65,7 +65,7 @@
 
       INTEGER :: alloc_status
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/cshprod.f90
+++ b/src/tools/cshprod.f90
@@ -208,7 +208,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/csjp.f90
+++ b/src/tools/csjp.f90
@@ -72,7 +72,7 @@
       INTEGER :: i, j, ig, ig1, icon, alloc_status
       INTEGER :: nin, nvarel, istrgv
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )
 

--- a/src/tools/csjprod.f90
+++ b/src/tools/csjprod.f90
@@ -218,7 +218,7 @@
 
       INTEGER :: i, ig, j, k, l, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, pi
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/cutest.f90
+++ b/src/tools/cutest.f90
@@ -143,57 +143,57 @@
         INTEGER :: lh_col = lmin
         INTEGER :: lh_val = lmin
         INTEGER :: io_buffer = io_buffer
-        REAL ( KIND = wp ) :: time_ccfg = 0.0_wp
-        REAL ( KIND = wp ) :: time_ccfsg = 0.0_wp
-        REAL ( KIND = wp ) :: time_cch = 0.0_wp
-        REAL ( KIND = wp ) :: time_cchprods = 0.0_wp
-        REAL ( KIND = wp ) :: time_cchprodsp = 0.0_wp
-        REAL ( KIND = wp ) :: time_ccifg = 0.0_wp
-        REAL ( KIND = wp ) :: time_ccifsg = 0.0_wp
-        REAL ( KIND = wp ) :: time_cdh = 0.0_wp
-        REAL ( KIND = wp ) :: time_cdhc = 0.0_wp
-        REAL ( KIND = wp ) :: time_cdimchp = 0.0_wp
-        REAL ( KIND = wp ) :: time_ceh = 0.0_wp
-        REAL ( KIND = wp ) :: time_cfn = 0.0_wp
-        REAL ( KIND = wp ) :: time_cgr = 0.0_wp
-        REAL ( KIND = wp ) :: time_cgrdh = 0.0_wp
-        REAL ( KIND = wp ) :: time_chcprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_chprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_cifn = 0.0_wp
-        REAL ( KIND = wp ) :: time_cigr = 0.0_wp
-        REAL ( KIND = wp ) :: time_cisgr = 0.0_wp
-        REAL ( KIND = wp ) :: time_cidh = 0.0_wp
-        REAL ( KIND = wp ) :: time_cish = 0.0_wp
-        REAL ( KIND = wp ) :: time_cjprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_clfg = 0.0_wp
-        REAL ( KIND = wp ) :: time_cofg = 0.0_wp
-        REAL ( KIND = wp ) :: time_cofsg = 0.0_wp
-        REAL ( KIND = wp ) :: time_csgr = 0.0_wp
-        REAL ( KIND = wp ) :: time_csgrp = 0.0_wp
-        REAL ( KIND = wp ) :: time_csjp = 0.0_wp
-        REAL ( KIND = wp ) :: time_csgreh = 0.0_wp
-        REAL ( KIND = wp ) :: time_csgrsh = 0.0_wp
-        REAL ( KIND = wp ) :: time_csgrshp = 0.0_wp
-        REAL ( KIND = wp ) :: time_csh = 0.0_wp
-        REAL ( KIND = wp ) :: time_cshc = 0.0_wp
-        REAL ( KIND = wp ) :: time_cshcprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_cshp = 0.0_wp
-        REAL ( KIND = wp ) :: time_cshprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_csjprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_cconst = 0.0_wp
-        REAL ( KIND = wp ) :: time_ubandh = 0.0_wp
-        REAL ( KIND = wp ) :: time_udh = 0.0_wp
-        REAL ( KIND = wp ) :: time_ueh = 0.0_wp
-        REAL ( KIND = wp ) :: time_ufn = 0.0_wp
-        REAL ( KIND = wp ) :: time_ugr = 0.0_wp
-        REAL ( KIND = wp ) :: time_ugrdh = 0.0_wp
-        REAL ( KIND = wp ) :: time_ugreh = 0.0_wp
-        REAL ( KIND = wp ) :: time_ugrsh = 0.0_wp
-        REAL ( KIND = wp ) :: time_uhprod = 0.0_wp
-        REAL ( KIND = wp ) :: time_uofg = 0.0_wp
-        REAL ( KIND = wp ) :: time_ush = 0.0_wp
-        REAL ( KIND = wp ) :: time_ushp = 0.0_wp
-        REAL ( KIND = wp ) :: time_ushprod = 0.0_wp
+        REAL :: time_ccfg = 0.0
+        REAL :: time_ccfsg = 0.0
+        REAL :: time_cch = 0.0
+        REAL :: time_cchprods = 0.0
+        REAL :: time_cchprodsp = 0.0
+        REAL :: time_ccifg = 0.0
+        REAL :: time_ccifsg = 0.0
+        REAL :: time_cdh = 0.0
+        REAL :: time_cdhc = 0.0
+        REAL :: time_cdimchp = 0.0
+        REAL :: time_ceh = 0.0
+        REAL :: time_cfn = 0.0
+        REAL :: time_cgr = 0.0
+        REAL :: time_cgrdh = 0.0
+        REAL :: time_chcprod = 0.0
+        REAL :: time_chprod = 0.0
+        REAL :: time_cifn = 0.0
+        REAL :: time_cigr = 0.0
+        REAL :: time_cisgr = 0.0
+        REAL :: time_cidh = 0.0
+        REAL :: time_cish = 0.0
+        REAL :: time_cjprod = 0.0
+        REAL :: time_clfg = 0.0
+        REAL :: time_cofg = 0.0
+        REAL :: time_cofsg = 0.0
+        REAL :: time_csgr = 0.0
+        REAL :: time_csgrp = 0.0
+        REAL :: time_csjp = 0.0
+        REAL :: time_csgreh = 0.0
+        REAL :: time_csgrsh = 0.0
+        REAL :: time_csgrshp = 0.0
+        REAL :: time_csh = 0.0
+        REAL :: time_cshc = 0.0
+        REAL :: time_cshcprod = 0.0
+        REAL :: time_cshp = 0.0
+        REAL :: time_cshprod = 0.0
+        REAL :: time_csjprod = 0.0
+        REAL :: time_cconst = 0.0
+        REAL :: time_ubandh = 0.0
+        REAL :: time_udh = 0.0
+        REAL :: time_ueh = 0.0
+        REAL :: time_ufn = 0.0
+        REAL :: time_ugr = 0.0
+        REAL :: time_ugrdh = 0.0
+        REAL :: time_ugreh = 0.0
+        REAL :: time_ugrsh = 0.0
+        REAL :: time_uhprod = 0.0
+        REAL :: time_uofg = 0.0
+        REAL :: time_ush = 0.0
+        REAL :: time_ushp = 0.0
+        REAL :: time_ushprod = 0.0
         LOGICAL :: record_times = .FALSE.
         LOGICAL :: array_status = .FALSE.
         LOGICAL :: hessian_setup_complete = .FALSE.

--- a/src/tools/timings.f90
+++ b/src/tools/timings.f90
@@ -16,8 +16,7 @@
 
       INTEGER, INTENT( OUT ) :: status
       CHARACTER ( LEN = * ), INTENT( IN ) :: name
-      REAL ( KIND = wp ), INTENT( out ) :: time
-
+      REAL, INTENT( out ) :: time
 !  ---------------------------------------------------------------------------
 !  return the total CPU time spent in the cutest evaluation tool called 'name'
 !  while the CPU monitor was turned on (see cutest_set_monitor). Timings are
@@ -51,7 +50,7 @@
       INTEGER, INTENT( IN ) :: thread
       INTEGER, INTENT( OUT ) :: status
       CHARACTER ( LEN = * ), INTENT( IN ) :: name
-      REAL ( KIND = wp ), INTENT( out ) :: time
+      REAL, INTENT( out ) :: time
 
 !  ---------------------------------------------------------------------------
 !  return the total CPU time spent in the cutest evaluation tool called 'name'
@@ -98,7 +97,7 @@
       TYPE ( CUTEST_work_type ) :: work
       INTEGER, INTENT( OUT ) :: status
       CHARACTER ( LEN = * ), INTENT( IN ) :: name
-      REAL ( KIND = wp ), INTENT( out ) :: time
+      REAL, INTENT( out ) :: time
 
 !  ---------------------------------------------------------------------------
 !  return the total CPU time spent in the cutest evaluation tool called 'name'
@@ -111,10 +110,10 @@
       SELECT CASE ( name )
       CASE ( 'start' )
         work%record_times = .TRUE.
-        time = 0.0_wp
+        time = 0.0
       CASE ( 'stop' )
         work%record_times = .FALSE.
-        time = 0.0_wp
+        time = 0.0
       CASE ( 'cutest_ccfg' )
         time = work%time_ccfg
       CASE ( 'cutest_ccfsg' )
@@ -211,7 +210,7 @@
         time = work%time_ushprod
       CASE DEFAULT
         status = 26
-        time = 0.0_wp
+        time = 0.0
         IF ( data%out > 0 ) WRITE( data%out,                                   &
           "( ' ** SUBROUTINE TIMINGS: unknown evaluation function ', A )" )    &
             TRIM ( name )

--- a/src/tools/ubandh.f90
+++ b/src/tools/ubandh.f90
@@ -132,7 +132,7 @@
 
       INTEGER :: i, ig, j, nsemiw, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/udh.f90
+++ b/src/tools/udh.f90
@@ -109,7 +109,7 @@
 
       INTEGER :: i, ig, j, k, nnzh, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ueh.f90
+++ b/src/tools/ueh.f90
@@ -279,7 +279,7 @@
       INTEGER :: i, j, ifstat, igstat, ig, alloc_status
       INTEGER :: lhe_row_int, lhe_val_int
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ufn.f90
+++ b/src/tools/ufn.f90
@@ -108,7 +108,7 @@
 
       INTEGER :: i, j, ig, ifstat, igstat
       REAL ( KIND = wp ) :: ftt, one, zero
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       PARAMETER ( zero = 0.0_wp, one = 1.0_wp )
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/ugr.f90
+++ b/src/tools/ugr.f90
@@ -105,7 +105,7 @@
 
       INTEGER :: i, j, ig, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/ugrdh.f90
+++ b/src/tools/ugrdh.f90
@@ -111,7 +111,7 @@
 
       INTEGER :: i, ig, j, k, nnzh, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ugreh.f90
+++ b/src/tools/ugreh.f90
@@ -283,7 +283,7 @@
       INTEGER :: i, ig, j, ifstat, igstat, lhe_row_int, lhe_val_int
       INTEGER :: alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ugrsh.f90
+++ b/src/tools/ugrsh.f90
@@ -125,7 +125,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/uhprod.f90
+++ b/src/tools/uhprod.f90
@@ -165,7 +165,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/uofg.f90
+++ b/src/tools/uofg.f90
@@ -168,7 +168,7 @@
 
       INTEGER :: i, j, ig, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/ureport.f90
+++ b/src/tools/ureport.f90
@@ -128,7 +128,7 @@
 
 !  local variable
 
-      REAL ( KIND = wp ) :: time_now
+      REAL :: time_now
 
       CALL CPU_TIME( time_now )
 

--- a/src/tools/ush.f90
+++ b/src/tools/ush.f90
@@ -119,7 +119,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat, alloc_status
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
       EXTERNAL :: RANGE
 

--- a/src/tools/ushp.f90
+++ b/src/tools/ushp.f90
@@ -64,7 +64,7 @@
 !  local variables
 
       INTEGER :: alloc_status
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       CHARACTER ( LEN = 80 ) :: bad_alloc = REPEAT( ' ', 80 )
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )

--- a/src/tools/ushprod.f90
+++ b/src/tools/ushprod.f90
@@ -209,7 +209,7 @@
 
       INTEGER :: i, ig, j, ifstat, igstat
       REAL ( KIND = wp ) :: ftt
-      REAL ( KIND = wp ) :: time_in, time_out
+      REAL :: time_in, time_out
       EXTERNAL :: RANGE
 
       IF ( work%record_times ) CALL CPU_TIME( time_in )


### PR DESCRIPTION
Variables passed to `CPU_TIME` should be of type `REAL`, independently of the working precision.