### PR TITLE
Fixed bug with cutest_scons in MATLAB interface

### DIFF
--- a/src/matlab/mcutest.c
+++ b/src/matlab/mcutest.c
@@ -1123,9 +1123,10 @@ extern "C" {
         J = (doublereal *)mxCalloc(CUTEst_nnzj, sizeof(doublereal));
         irow = (integer *)mxCalloc(CUTEst_nnzj, sizeof(integer));
         jcol = (integer *)mxCalloc(CUTEst_nnzj, sizeof(integer));
+        integer CUTEst_nnzj0 = CUTEst_nnzj;
 
         CUTEST_ccfsg( &status, &CUTEst_nvar, &CUTEst_ncon, x, c, &CUTEst_nnzj,
-              &CUTEst_nnzj, J, jcol, irow, &somethingTrue);
+              &CUTEst_nnzj0, J, jcol, irow, &somethingTrue);
         if (status != 0) {
             sprintf(msgBuf,"** CUTEst error, status = %d, aborting\n", status);
             mexErrMsgTxt(msgBuf);


### PR DESCRIPTION
The routine cutest_scons was throwing the following error on all problems:

[ans J] = cutest_scons(prob.x);
Error using mcutest
** CUTEst error, status = 2, aborting

Error in cutest_scons (line 7)
    [varargout{:}] = mcutest('scons',varargin{:});

It appears that CUTEST_ccfsg was being called incorrectly where the parameter CUTEst_nnzj was being passed as both an input and an output in multiple positions.  This led to an error where CUTEst thought that there was not enough memory for allocation of the Jacobian.

To fix this, I simply duplicated CUTEst_nnzj before the call.  It's a single integer, so it's not that much memory.  After the fix, everything seems to work fine.