### PR TITLE
errors in single precision

### DIFF
--- a/src/gen90/gen90.f90
+++ b/src/gen90/gen90.f90
@@ -1,6 +1,7 @@
 !     ( Last modified on 23 Dec 2000 at 22:01:39 )
 
 MODULE Generic_Driver
+  ! BOGUS CHANGE TO TRIGGER BUILD
 
   IMPLICIT NONE
   PRIVATE


### PR DESCRIPTION
GEN77 and GENC are not available in single precision. The Intel compiler complains about GEN90 in single precision.