### PR TITLE
[Meson] Add a missing macro to compile CUTEst in quadruple precision

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -138,11 +138,15 @@ jobs:
           else
             MODE="shared"
           fi
+          QUADRUPLE="true"
+          if [[ "${{ matrix.compiler }}" == "intel-classic" || "${{ matrix.compiler }}" == "intel" ]]; then
+            QUADRUPLE="false"
+          fi
           meson setup builddir --buildtype=debug \
                                --prefix=$GITHUB_WORKSPACE/cutest \
                                -Ddefault_library=${MODE} \
-                               -Dquadruple=true \
-                               -Dint64=$INT64
+                               -Dquadruple=${QUADRUPLE} \
+                               -Dint64=${INT64}
 
       - name: Build CUTEST
         shell: bash

--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,7 @@ if build_quadruple
 
   gen_quadruple = generator(fc_compiler,
                             output : 'quadruple_@BASENAME@.f90',
-                            arguments : pp_options + '-DREAL_128' +
+                            arguments : pp_options + '-DREAL_128' + '-DCUTEST_16btye_reals_exist' +
                                         ['-I', '@CURRENT_SOURCE_DIR@/include', '@INPUT@'] +
                                         output_generator)
 


### PR DESCRIPTION
@nimgould @jfowkes 
Thanks for the treasure hunt!
Hiding a macro that’s documented nowhere to compile the quadruple version of `CUTEst` was a great way to keep me on my toes. 😅
-> https://github.com/ralna/CUTEst/blob/master/src/tools/kinds.F90#L151-L157