### PR TITLE
[Meson] Add unit tests in Fortran

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -130,12 +130,13 @@ jobs:
         shell: bash
         run: |
           INT64="false"
+          TESTS="true"
           if [[ "${{matrix.int}}" == "64" ]]; then
             INT64="true"
+            TESTS="false"
           fi
           if [[ "${{matrix.mode}}" == "static" ]]; then
             MODE="static"
-            TESTS="true"
           else
             MODE="shared"
             TESTS="false"

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -135,8 +135,10 @@ jobs:
           fi
           if [[ "${{matrix.mode}}" == "static" ]]; then
             MODE="static"
+            TESTS="true"
           else
             MODE="shared"
+            TESTS="false"
           fi
           QUADRUPLE="true"
           if [[ "${{ matrix.compiler }}" == "intel-classic" || "${{ matrix.compiler }}" == "intel" ]]; then
@@ -146,7 +148,8 @@ jobs:
                                --prefix=$GITHUB_WORKSPACE/cutest \
                                -Ddefault_library=${MODE} \
                                -Dquadruple=${QUADRUPLE} \
-                               -Dint64=${INT64}
+                               -Dint64=${INT64} \
+                               -Dtests=${TESTS}
 
       - name: Build CUTEST
         shell: bash

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ fc_compiler = find_program(fc.cmd_array())
 install_modules = get_option('modules')
 build_quadruple = get_option('quadruple')
 int64 = get_option('int64')
+build_tests = get_option('tests')
 
 libcutest_src = []
 libcutest_f_src = []
@@ -88,7 +89,7 @@ subdir('src/stats')
 # subdir('src/stenmin')      # needs stumcd_
 # subdir('src/tao')          # needs petsc/finclude/petsctao.h and Fortran module petsctao
 # subdir('src/tenmin')       # needs tensor_
-# subdir('src/test')
+subdir('src/test')
 subdir('src/tools')
 # subdir('src/tron')         # needs dnrm2_, dgpnrm2_
 # subdir('src/uncmin')       # needs optif9_
@@ -121,9 +122,11 @@ elif fc.get_id() == 'nvidia_hpc'
   pp_options += ['-Mcpp', '-F']
 endif
 if int64
+  pp_flag += '-DINTEGER_64'
   pp_options += '-DINTEGER_64'
 endif
 if host_machine.system() == 'windows'
+  pp_flag += '-DWINDOWS'
   pp_options += '-DWINDOWS'
 endif
 
@@ -209,4 +212,42 @@ install_headers(cutest_headers)
 if install_modules
   script_modules = files('install_modules.py')
   meson.add_install_script(script_modules)
+endif
+
+# Fortran tests
+if build_tests
+
+  fortran_tests_folder = 'tests/Fortran'
+
+  foreach test: cutest_tests
+    package = test[0]
+    precision = test[1]
+    name = test[2]
+    file = test[3]
+
+    if precision == 'single'
+      libgalahad_precision = libcutest_single
+      args_precision = pp_flag + '-DREAL_32'
+    endif
+    if precision == 'double'
+      libgalahad_precision = libcutest_double
+      args_precision = pp_flag
+    endif
+    if precision == 'quadruple'
+      libgalahad_precision = libcutest_quadruple
+      args_precision = pp_flag + '-DREAL_128' + '-DCUTEST_16btye_reals_exist'
+    endif
+
+    test(name,
+         executable(name, file,
+                    fortran_args : args_precision,
+                    link_with : libgalahad_precision,
+                    link_language : 'fortran',
+                    include_directories: libcutest_include,
+                    install : true,
+                    install_dir : fortran_tests_folder),
+         suite : [package, precision, 'fortran'],
+         workdir : join_paths(meson.project_source_root(), 'src', 'test'),
+         is_parallel : false)
+    endforeach
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,8 @@ option('int64',
        type : 'boolean',
        value : false,
        description : 'option to compile CUTEst with 64-bit integer')
+
+option('tests',
+       type : 'boolean',
+       value : false,
+       description : 'whether to generate the tests')

--- a/src/test/ctest.F90
+++ b/src/test/ctest.F90
@@ -98,7 +98,7 @@
 
       WRITE( out, "( ' CALL CUTEST_csetup ' )" )
       CALL CUTEST_csetup_r( status, input, out, buffer, n, m, X, X_l, X_u,     &
-                      Y, C_l, C_u, EQUATION, LINEAR, 1, 1, 1 )
+                      Y, C_l, C_u, EQUATION, LINEAR, 1_ip_, 1_ip_, 1_ip_ )
       IF ( status /= 0 ) GO TO 900
       CALL WRITE_X( out, n, X, X_l, X_u )
       CALL WRITE_Y( out, m, Y, C_l, C_u, EQUATION, LINEAR )
@@ -876,7 +876,7 @@
 
       WRITE( out, "( ' CALL CUTEST_csetup ' )" )
       CALL CUTEST_csetup_r( status, input, out, buffer, n, m, X, X_l, X_u,     &
-                             Y, C_l, C_u, EQUATION, LINEAR, 1, 1, 1 )
+                             Y, C_l, C_u, EQUATION, LINEAR, 1_ip_, 1_ip_, 1_ip_ )
       IF ( status /= 0 ) GO TO 900
 
 !  ... and terminal exit

--- a/src/test/ctest2.F90
+++ b/src/test/ctest2.F90
@@ -98,7 +98,7 @@
 
       WRITE( out, "( ' CALL CUTEST_csetup ' )" )
       CALL CUTEST_csetup_r( status, input, out, buffer, n, m, X, X_l, X_u,     &
-                      Y, C_l, C_u, EQUATION, LINEAR, 1, 1, 1 )
+                      Y, C_l, C_u, EQUATION, LINEAR, 1_ip_, 1_ip_, 1_ip_ )
       IF ( status /= 0 ) GO TO 900
       CALL WRITE_X( out, n, X, X_l, X_u )
       CALL WRITE_Y( out, m, Y, C_l, C_u, EQUATION, LINEAR )

--- a/src/test/ctest_threaded.F90
+++ b/src/test/ctest_threaded.F90
@@ -101,7 +101,7 @@
       WRITE( out, "( ' CALL CUTEST_csetup ' )" )
       CALL CUTEST_csetup_threaded_r( status, input, out, threads, BUFFER,      &
                                      n, m, X, X_l, X_u,                        &
-                                     Y, C_l, C_u, EQUATION, LINEAR, 1, 1, 1 )
+                                     Y, C_l, C_u, EQUATION, LINEAR, 1_ip_, 1_ip_, 1_ip_ )
       IF ( status /= 0 ) GO to 900
       CALL WRITE_X( out, n, X, X_l, X_u )
       CALL WRITE_Y( out, m, Y, C_l, C_u, EQUATION, LINEAR )
@@ -827,7 +827,7 @@
 !  calls and time report
 
 !     WRITE( out, "( ' CALL CUTEST_creport for thread 1' )" )
-!     CALL CUTEST_creport_threaded_r( status, CALLS, CPU, 1 )
+!     CALL CUTEST_creport_threaded_r( status, CALLS, CPU, 1_ip_ )
 !     WRITE( out, "( ' CALLS(1-7) =', 7( 1X, I0 ) )" ) INT( CALLS( 1 : 7 ) )
 !     WRITE( out, "( ' CPU(1-4) =', 4F7.2 )" ) CPU( 1 : 4 )
 

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -1,0 +1,16 @@
+cutest_tests += [['cutest', 'single', 'ctest_single'         , files('ctest.F90'         , 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
+                 ['cutest', 'single', 'ctest_threaded_single', files('ctest_threaded.F90', 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
+                 ['cutest', 'single', 'utest_single'         , files('utest.F90'         , 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
+                 ['cutest', 'single', 'utest_threaded_single', files('utest_threaded.F90', 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
+                 ['cutest', 'double', 'ctest_double'         , files('ctest.F90'         , 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
+                 ['cutest', 'double', 'ctest_threaded_double', files('ctest_threaded.F90', 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
+                 ['cutest', 'double', 'utest_double'         , files('utest.F90'         , 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
+                 ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
+
+# u_elfun_quadruple.f is missing in src/test
+# if build_quadruple
+#     cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+#                      ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+#                      ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
+#                      ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
+# endif

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -8,9 +8,9 @@ cutest_tests += [['cutest', 'single', 'ctest_single'         , files('ctest.F90'
                  ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
 
 # u_elfun_quadruple.f is missing in src/test
-# if build_quadruple
-#     cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
-#                      ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
-#                      ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
-#                      ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
-# endif
+if build_quadruple
+    cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+                     ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')]]
+                     # ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
+                     # ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
+endif

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -7,10 +7,9 @@ cutest_tests += [['cutest', 'single', 'ctest_single'         , files('ctest.F90'
                  ['cutest', 'double', 'utest_double'         , files('utest.F90'         , 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
                  ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
 
-# u_elfun_quadruple.f is missing in src/test
 if build_quadruple
     cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
-                     ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')]]
-                     # ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
-                     # ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
+                     ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+                     ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
+                     ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
 endif

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -2,14 +2,17 @@ cutest_tests += [['cutest', 'single', 'ctest_single'         , files('ctest.F90'
                  ['cutest', 'single', 'ctest_threaded_single', files('ctest_threaded.F90', 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
                  ['cutest', 'single', 'utest_single'         , files('utest.F90'         , 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
                  ['cutest', 'single', 'utest_threaded_single', files('utest_threaded.F90', 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
+                 ['cutest', 'single', 'lqp_test_single'      , files('lqptest.F90'       , 'q_elfun_single.f', 'q_group_single.f', 'q_range_single.f')],
                  ['cutest', 'double', 'ctest_double'         , files('ctest.F90'         , 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
                  ['cutest', 'double', 'ctest_threaded_double', files('ctest_threaded.F90', 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
                  ['cutest', 'double', 'utest_double'         , files('utest.F90'         , 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
-                 ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
+                 ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
+                 ['cutest', 'double', 'lqp_test_double'      , files('lqptest.F90'       , 'q_elfun_double.f', 'q_group_double.f', 'q_range_double.f')]]
 
 if build_quadruple
     cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
                      ['cutest', 'quadruple', 'ctest_threaded_quadruple', files('ctest_threaded.F90', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
                      ['cutest', 'quadruple', 'utest_quadruple'         , files('utest.F90'         , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
-                     ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
+                     ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
+                     ['cutest', 'quadruple', 'lqp_test_quadruple'      , files('lqptest.F90'       , 'q_elfun_quadruple.f', 'q_group_quadruple.f', 'q_range_quadruple.f')]]
 endif

--- a/src/test/utest.F90
+++ b/src/test/utest.F90
@@ -33,6 +33,7 @@
       INTEGER ( KIND = ip_ ) :: i, n, HE_nel, HE_val_ne, HE_row_ne, status
       INTEGER ( KIND = ip_ ) :: l_h2_1, l_h, lhe_ptr, H_ne, lhe_val, lhe_row
       INTEGER ( KIND = ip_ ) :: nnz_vector, nnz_result, maxsbw, alloc_stat
+      INTEGER ( KIND = ip_ ) :: nsemib, lbandh
       REAL ( KIND = rp_ ) :: f
       LOGICAL :: grad, byrows, goth
       CHARACTER ( len = 10 ) ::  p_name
@@ -512,7 +513,7 @@
 
 !     SUBROUTINE WRITE_H_BAND( out, n, lbandh, H_band, nsemib, maxsbw )
       SUBROUTINE WRITE_H_BAND( out, n, lbandh, H_band, nsemib )
-      INTEGER ( KIND = ip_ ) :: n, lbandh, out
+      INTEGER ( KIND = ip_ ) :: n, lbandh, nsemib, out
 !     INTEGER ( KIND = ip_ ) :: maxsbw
       REAL ( KIND = rp_ ), DIMENSION( 0 : lbandh, n ):: H_band
       INTEGER ( KIND = ip_ ) :: i, j

--- a/src/test/utest_threaded.F90
+++ b/src/test/utest_threaded.F90
@@ -36,6 +36,7 @@
       INTEGER ( KIND = ip_ ) :: i, n, HE_nel, HE_val_ne, HE_row_ne, status
       INTEGER ( KIND = ip_ ) :: l_h2_1, l_h, lhe_ptr, H_ne, lhe_val, lhe_row
       INTEGER ( KIND = ip_ ) :: nnz_vector, nnz_result, maxsbw, alloc_stat
+      INTEGER ( KIND = ip_ ) :: nsemib, lbandh
       REAL ( KIND = rp_ ) :: f
       LOGICAL :: grad, byrows, goth
       CHARACTER ( len = 10 ) ::  p_name
@@ -517,7 +518,7 @@
 
 !     SUBROUTINE WRITE_H_BAND( out, n, lbandh, H_band, nsemib, maxsbw )
       SUBROUTINE WRITE_H_BAND( out, n, lbandh, H_band, nsemib )
-      INTEGER ( KIND = ip_ ) :: n, lbandh, out
+      INTEGER ( KIND = ip_ ) :: n, lbandh, nsemib, out
 !     INTEGER ( KIND = ip_ ) :: maxsbw
       REAL ( KIND = rp_ ), DIMENSION( 0 : lbandh, n ):: H_band
       INTEGER ( KIND = ip_ ) :: i, j


### PR DESCRIPTION
Nick, it seems that a file `u_elfun_quadruple.f` is missing in `src/test`.
I have some comments on the Fortran tests:

- We have an error with threaded tests:
```shell
# /home/alexis/Applications/CUTEst/builddir4/ctest_threaded_double
# /home/alexis/Applications/CUTEst/builddir4/ctest_threaded_single
 CALL CUTEST_cdhj
 ** CUTEST error: thread -1717986918 out of range [1,4]
 error status = 4
```
Meson doesn't return en error because it just prints things and it's not a segmentation fault.

- If I compile CUTEst with 64-bit integer, I have this error:
```shell

alexis@HP-Spectre:~/Applications/CUTEst/src/test$ /home/alexis/Applications/CUTEst/builddir4/ctest_threaded_single
 CALL CUTEST_cdimen 
 * n = 5, m = 1
 CALL CUTEST_cnoobj 
 there is an objective function
 CALL CUTEST_csetup 
 *       i      X_l          X          X_u
 *       1 -1.0000E+20  0.0000E+00  1.0000E+20
 *       2  1.0000E+00  0.0000E+00  1.0000E+20
 *       3 -1.0000E+10  0.0000E+00  1.0000E+00
 *       4  2.0000E+00  0.0000E+00  2.0000E+00
 *       5  0.0000E+00  0.0000E+00  1.0000E+20
 *       i      C_l         C_u          Y         EQUATION   LINEAR
 *       1  0.0000E+00  0.0000E+00  0.0000E+00         T         F
 CALL CUTEST_cstats
 * nonlinear_variables_objective = 5
 * nonlinear_variables_constraints = 2
 * equality_constraints = 1
 * linear_constraints = 0
 CALL CUTEST_cnames
 * p_name = ALLINITC4 
 *       i  X_name
 *       1  X1        
 *       2  X2        
 *       3  X3        
 *       4  X4        
 *       5  X5        
 *       i  C_name
 *       1  C1        
 Call CUTEST_connames
 *       i  C_name
 *       1  C1        
 CALL CUTEST_cvartype
 *       i  X_type
 *       1  0
 *       2  0
 *       3  0
 *       4  0
 *       5  0
 CALL CUTEST_cfn
 ** SUBROUTINE CFN: error flag raised during SIF evaluation
 error status = 3
```
- Which test(s) should use `q_group_*.f`, `q_elfun_*.f`, `q_range_*.f`?
- Should I use `ctest.F90` and / or `ctest2.F90`? 