### PR TITLE
[Meson] Add files ctest_c.c and utest_c.c

### DIFF
--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -9,10 +9,14 @@ cutest_tests += [['cutest', 'single', 'ctest_single'         , files('ctest.F90'
                  ['cutest', 'double', 'utest_threaded_double', files('utest_threaded.F90', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
                  ['cutest', 'double', 'lqp_test_double'      , files('lqptest.F90'       , 'q_elfun_double.f', 'q_group_double.f', 'q_range_double.f')]]
 
-cutest_c_tests += [['cutest', 'single', 'ctest_c_single', files('ctest.c', 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
-                   ['cutest', 'double', 'ctest_c_double', files('ctest.c', 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
-                   ['cutest', 'single', 'utest_c_single', files('utest.c', 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
-                   ['cutest', 'double', 'utest_c_double', files('utest.c', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
+cutest_c_tests += [['cutest', 'single', 'ctest_c_single' , files('ctest.c'  , 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
+                   ['cutest', 'single', 'utest_c_single' , files('utest.c'  , 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
+                   ['cutest', 'single', 'ctest2_c_single', files('ctest_c.c', 'c_elfun_single.f', 'c_group_single.f', 'c_range_single.f')],
+                   ['cutest', 'single', 'utest2_c_single', files('utest_c.c', 'u_elfun_single.f', 'u_group_single.f', 'u_range_single.f')],
+                   ['cutest', 'double', 'ctest_c_double' , files('ctest.c'  , 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
+                   ['cutest', 'double', 'utest_c_double' , files('utest.c'  , 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')],
+                   ['cutest', 'double', 'ctest2_c_double', files('ctest_c.c', 'c_elfun_double.f', 'c_group_double.f', 'c_range_double.f')],
+                   ['cutest', 'double', 'utest2_c_double', files('utest_c.c', 'u_elfun_double.f', 'u_group_double.f', 'u_range_double.f')]]
 
 if build_quadruple
     cutest_tests += [['cutest', 'quadruple', 'ctest_quadruple'         , files('ctest.F90'         , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
@@ -21,6 +25,8 @@ if build_quadruple
                      ['cutest', 'quadruple', 'utest_threaded_quadruple', files('utest_threaded.F90', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
                      ['cutest', 'quadruple', 'lqp_test_quadruple'      , files('lqptest.F90'       , 'q_elfun_quadruple.f', 'q_group_quadruple.f', 'q_range_quadruple.f')]]
 
-    cutest_c_tests += [['cutest', 'quadruple', 'ctest_c_quadruple', files('ctest.c', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
-                       ['cutest', 'quadruple', 'utest_c_quadruple', files('utest.c', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
+    cutest_c_tests += [['cutest', 'quadruple', 'ctest_c_quadruple' , files('ctest.c'  , 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+                       ['cutest', 'quadruple', 'utest_c_quadruple' , files('utest.c'  , 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')],
+                       ['cutest', 'quadruple', 'ctest2_c_quadruple', files('ctest_c.c', 'c_elfun_quadruple.f', 'c_group_quadruple.f', 'c_range_quadruple.f')],
+                       ['cutest', 'quadruple', 'utest2_c_quadruple', files('utest_c.c', 'u_elfun_quadruple.f', 'u_group_quadruple.f', 'u_range_quadruple.f')]]
 endif


### PR DESCRIPTION
@nimgould 
You forgot to push the header `cutest_c.h`.

Should we also rename the C tests with the "Fortran-like" API `ctest.c` and `utest.c` into `ctestf.c` and `utestf.c`?