### PR TITLE
Do not pass preprocessor flag to C compiler

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -280,20 +280,35 @@ if build_tests and (fc.get_id() == 'gcc')
     if precision == 'single'
       libcutest_precision = libcutest_single
       args_precision = pp_flag + '-DREAL_32'
+      if cc.get_id() == 'clang'
+        c_args_precision = '-DREAL_32'
+      else
+        c_args_precision = args_precision
+      endif
     endif
     if precision == 'double'
       libcutest_precision = libcutest_double
       args_precision = pp_flag
+      if cc.get_id() == 'clang'
+        c_args_precision = ''
+      else
+        c_args_precision = args_precision
+      endif
     endif
     if precision == 'quadruple'
       libcutest_precision = libcutest_quadruple
       args_precision = pp_flag + '-DREAL_128'
+      if cc.get_id() == 'clang'
+        c_args_precision = '-DREAL_128'
+      else
+        c_args_precision = args_precision
+      endif
     endif
 
     test(name,
          executable(name, file,
                     fortran_args : args_precision,
-                    c_args : args_precision,
+                    c_args : c_args_precision,
                     link_with : libcutest_precision,
                     link_language : 'fortran',
                     include_directories: libcutest_include,

--- a/meson.build
+++ b/meson.build
@@ -99,8 +99,8 @@ subdir('src/stats')
 # subdir('src/stenmin')      # needs stumcd_
 # subdir('src/tao')          # needs petsc/finclude/petsctao.h and Fortran module petsctao
 # subdir('src/tenmin')       # needs tensor_
-subdir('src/test')
 subdir('src/tools')
+subdir('src/test')
 # subdir('src/tron')         # needs dnrm2_, dgpnrm2_
 # subdir('src/uncmin')       # needs optif9_
 # subdir('src/vf13')         # needs vf13ad_
@@ -237,7 +237,7 @@ if build_tests
     package = test[0]
     precision = test[1]
     name = test[2]
-    file = test[3]
+    file = tests_common_src + test[3]
 
     if precision == 'single'
       libcutest_precision = libcutest_single

--- a/src/tools/meson.build
+++ b/src/tools/meson.build
@@ -96,3 +96,5 @@ libcutest_src += files('ccf.F90',
 if get_option('default_library') == 'shared'
     libcutest_src += files('cutest_trampoline.f90')
 endif
+
+tests_common_src = files('interface.F90')


### PR DESCRIPTION
When building with clang (the default on macOS), the build fails because -cpp is not recognized.

Fixes the first part of #99.